### PR TITLE
feat: actualiza estilos del menú lateral móvil con nuevos íconos y an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.6",
         "autoprefixer": "^10.4.21",
         "framer-motion": "^12.11.3",
+        "lucide-react": "^0.511.0",
         "postcss": "^8.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3331,6 +3332,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.511.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
+      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/vite": "^4.1.6",
     "autoprefixer": "^10.4.21",
     "framer-motion": "^12.11.3",
+    "lucide-react": "^0.511.0",
     "postcss": "^8.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -16,7 +16,7 @@ const Header = () => {
   return (
     <>
       <header className='w-full h-16 bg-white shadow-md sticky top-0 flex justify-between items-center px-[15px]'>
-        <div className='w-[110px]'>
+        <div className='w-[100px]'>
           <img src="/pyme-up-gray-logo.png" alt="Gray logo of PymeUp" />
         </div>
         <button onClick={() => { openMenu() }}>

--- a/src/components/SideBarMobile/SideBarMobile.jsx
+++ b/src/components/SideBarMobile/SideBarMobile.jsx
@@ -1,26 +1,59 @@
-import React from 'react'
+import React from "react";
+import { Home, Code, Wrench, Info, FileText, Users, Rocket } from 'lucide-react';
 
 const SideBarMobile = ({ isOpen, closeMenu }) => {
-    return (
-        <aside className={`fixed top-0 right-0 h-full w-64 bg-[#bbbbbb49] text-[#373737] backdrop-blur-[30px] shadow-xl transform transition-transform duration-300 ease-in-out z-40  ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
-            <button onClick={() => { closeMenu() }} className="absolute top-3 right-4">
-                <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" className="bi bi-x-lg" viewBox="0 0 16 16">
-                    <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z" />
-                </svg>
-            </button>
-            <div className='w-full h-[500px] flex flex-col justify-between items-center mt-[50px]'>
-                <ul className='w-full flex flex-col gap-[15px] pl-[20px] '>
-                    <li className='font-semibold text-[20px]'>Home</li>
-                    <li className='font-semibold text-[20px]'>Problems</li>
-                    <li className='font-semibold text-[20px]'>Solutions</li>
-                    <li className='font-semibold text-[20px]'>About</li>
-                    <li className='font-semibold text-[20px]'>Blog</li>
-                    <li className='font-semibold text-[20px]'>Team</li>
-                </ul>
-                <button className="w-[220px] h-11 font-medium border-2 border-[#373737] rounded-2xl cursor-pointer transition ease-in-out hover:bg-[#373737] hover:border-2 hover:text-white">I’m Ready to Grow</button>
-            </div>
-        </aside>
-    )
-}
+const menuItems = [
+  { icon: <Home size={20} />, label: "Home" },
+  { icon: <Code size={20} />, label: "Problems" },
+  { icon: <Wrench size={20} />, label: "Solutions" },
+  { icon: <Info size={20} />, label: "About" },
+  { icon: <FileText size={20} />, label: "Blog" },
+  { icon: <Users size={20} />, label: "Team" },
+  { icon: <Rocket size={20} />, label: "I’m Ready to Grow" },
+];
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="bg-black/75 fixed inset-0  z-40 transition-opacity duration-300"
+          onClick={closeMenu}
+        />
+      )}
+      <aside
+        className={`fixed bottom-0 left-0 w-full  mx-auto h-[90%] bg-white text-[#373737] shadow-2xl rounded-t-2xl transform transition-transform duration-300 ease-in-out z-50 ${
+          isOpen ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        <button
+          onClick={closeMenu}
+          className="absolute top-4 right-4 text-gray-500 hover:text-black"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="26"
+            height="26"
+            fill="currentColor"
+            viewBox="0 0 16 16"
+          >
+            <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z" />
+          </svg>
+        </button>
+        <nav className="mt-16 px-6">
+          <ul className="space-y-4">
+            {menuItems.map((item, index) => (
+              <li
+                key={index}
+                className="flex items-center gap-3 text-base text-gray-700 hover:bg-gray-100 px-3 py-2 rounded-xl transition cursor-pointer"
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+    </>
+  );
+};
 
-export default SideBarMobile
+export default SideBarMobile;


### PR DESCRIPTION
…imación desde abajo

- Se mejora la experiencia visual del menú móvil deslizándolo desde abajo
- Se aumenta el alto del menú al 90% del viewport
- Se añade fondo negro translúcido con desenfoque al desplegar el menú
- Se actualizan íconos de navegación usando lucide-react para mayor semántica:
  - Home → Home
  - Problems → Code
  - Solutions → Wrench
  - About → Info
  - Blog → FileText
  - Team → Users
  - I’m Ready to Grow → Rocket